### PR TITLE
Add support for S3 compatible storages 

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ Start by creating an API Token for your Atlassian account: https://id.atlassian.
 ```
 Additional authentication methods such as [IAM Roles for Amazon EC2](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html) are supported. You many need to set additional environment variables to configure certain methods. See [boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html) for details.
 
+### AWS compartable services
+
+Following environment variables allows to use any custom services:
+
+* S3_ENDPOINT
+* S3_REGION
+
 ### Docker
 To use the container, replace all placeholders with the actual values and run the following command:
 

--- a/backup.py
+++ b/backup.py
@@ -19,9 +19,9 @@ class Atlassian:
         print('-> Starting backup; include attachments: {}'.format(os.environ['INCLUDE_ATTACHMENTS']))
 
         s3config = {}
-        if os.environ['S3_REGION']:
+        if 'S3_REGION' in os.environ:
             s3config["region_name"] = os.environ['S3_REGION']
-        if os.environ['S3_ENDPOINT']:
+        if 'S3_ENDPOINT' in os.environ:
             s3config["endpoint_url"] = os.environ['S3_ENDPOINT']
 
         self.session = requests.Session()

--- a/backup.py
+++ b/backup.py
@@ -18,8 +18,14 @@ class Atlassian:
 
         print('-> Starting backup; include attachments: {}'.format(os.environ['INCLUDE_ATTACHMENTS']))
 
+        s3config = {}
+        if os.environ['S3_REGION']:
+            s3config["region_name"] = os.environ['S3_REGION']
+        if os.environ['S3_ENDPOINT']:
+            s3config["endpoint_url"] = os.environ['S3_ENDPOINT']
+
         self.session = requests.Session()
-        self.s3 = boto3.client('s3')
+        self.s3 = boto3.client('s3', **s3config)
         self.session.auth = (os.environ['USER_EMAIL'], os.environ['API_TOKEN'])
         self.session.headers.update({'Content-Type': 'application/json', 'Accept': 'application/json'})
         self.payload = {"cbAttachments": os.environ['INCLUDE_ATTACHMENTS'], "exportToCloud": "true"}


### PR DESCRIPTION
Two additional environment variables added:
* S3_ENDPOINT
* S3_REGION
allowing to use any compatible S3 providers

For example, you can upload backups to DigitalOcean with following example values:
```
S3_ENDPOINT="https://fra1.digitaloceanspaces.com"
S3_REGION="fra1"
```